### PR TITLE
Issue #8 Fixes .error is deprecated

### DIFF
--- a/aura/inputLookup/inputLookupHelper.js
+++ b/aura/inputLookup/inputLookupHelper.js
@@ -71,7 +71,7 @@
 
         action.setCallback(this, function(a) {
             if(a.error && a.error.length){
-                return $A.error('Unexpected error: '+a.error[0].message);
+                throw new Error('Unexpected error: '+a.error[0].message);
             }
             var result = a.getReturnValue();
             var matches, substrRegex;
@@ -132,7 +132,7 @@
         
         action.setCallback(this, function(a) {
             if(a.error && a.error.length){
-                return $A.error('Unexpected error: '+a.error[0].message);
+                throw new Error('Unexpected error: '+a.error[0].message);
             }
             var result = a.getReturnValue();
             var globalId = component.getGlobalId();


### PR DESCRIPTION
This replaces the deprecated $A.error with the JS standard throw new Error per Salesforce documentation.

https://releasenotes.docs.salesforce.com/en-us/spring16/release-notes/rn_lightning_js_deprecated.htm